### PR TITLE
feat: Add header navigation for page Arcs

### DIFF
--- a/script.js
+++ b/script.js
@@ -238,14 +238,37 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     ];
 
+    const uniqueArcs = [...new Set(games.map(game => game.arc))];
+
     const timelineContainer = document.getElementById('game-timeline-container');
     let lastArc = null;
+
+    // Create and add Arc navigation
+    const headerElement = document.querySelector('header');
+    if (headerElement) {
+        const arcNav = document.createElement('nav');
+        arcNav.className = 'arc-navigation';
+
+        uniqueArcs.forEach(arc => {
+            const link = document.createElement('a');
+            link.textContent = arc;
+            link.href = '#' + arc.toLowerCase().replace(/\s+/g, '-') + '-header';
+            arcNav.appendChild(link);
+
+            if (uniqueArcs.indexOf(arc) < uniqueArcs.length - 1) {
+                const separator = document.createTextNode(' • ');
+                arcNav.appendChild(separator);
+            }
+        });
+        headerElement.appendChild(arcNav);
+    }
 
     games.forEach((game) => {
         if (game.arc !== lastArc) {
             const arcHeader = document.createElement('h2');
             arcHeader.className = 'arc-header';
             arcHeader.textContent = game.arc;
+            arcHeader.id = game.arc.toLowerCase().replace(/\s+/g, '-') + '-header';
             timelineContainer.appendChild(arcHeader);
             lastArc = game.arc;
         }

--- a/style.css
+++ b/style.css
@@ -114,3 +114,26 @@ main { padding: 2rem 1rem; max-width: 1300px; margin: 0 auto; }
 @media (max-width: 900px) {
     .game-entry { flex-direction: column; align-items: center; }
 }
+
+/* Arc Navigation Styling */
+.arc-navigation {
+    text-align: center; /* Center the navigation links */
+    margin-top: 15px; /* Add some space above the navigation */
+    margin-bottom: 10px; /* Add some space below the navigation */
+    padding: 5px 0; /* Add some vertical padding */
+    color: #cccccc; /* Light gray color for '•' separators (inherited by text nodes) */
+}
+
+.arc-navigation a {
+    font-family: 'Inter', sans-serif; /* Match font if needed, or choose a suitable one */
+    font-weight: bold;
+    font-size: 0.9em;
+    color: #cccccc; /* Light gray color for links, adjust as needed */
+    text-decoration: none; /* Remove underline from links */
+    margin: 0 5px; /* Add small horizontal margin around links for spacing */
+}
+
+.arc-navigation a:hover {
+    color: #ffffff; /* White color on hover, adjust as needed */
+    text-decoration: underline; /* Underline on hover for better affordance */
+}


### PR DESCRIPTION
This commit introduces a new navigation feature in the page header, allowing you to quickly jump to specific Arcs within the timeline.

Key changes:

-   `script.js`:
    -   Modified to assign unique IDs to each `<h2>` Arc header
      (e.g., 'liberl-arc-header').
    -   Added logic to dynamically generate navigation links in the
      header. These links correspond to each unique Arc present in the
      `games` data and use anchor links to jump to the Arc headers.
    -   Separators (" • ") are included between the links for clarity.

-   `style.css`:
    -   Added new CSS rules to style the Arc navigation bar.
    -   Styles include text centering, link appearance (font, color,
      hover effects), and spacing to match the requested format of
      "Liberl • Crossbell • etc."

The navigation enhances your experience by providing quick access to different sections of the game timeline.