### PR TITLE
Remove unnecessary color key from Lore Timeline

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -4,7 +4,6 @@ document.addEventListener('DOMContentLoaded', () => {
     let minDate, maxDate;
 
     // --- DOM Elements ---
-    const colorKeyContainer = document.getElementById('game-color-key-container');
     const timeAxisContainer = document.getElementById('time-axis-container');
     const gameColumnsContainer = document.getElementById('game-columns-container');
     const liberlColumn = document.getElementById('liberl-arc-column').querySelector('.game-entries-area');
@@ -53,7 +52,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 return;
             }
             renderTimeAxis();
-            renderColorKey();
             renderGameEntries();
 
         } catch (error) {
@@ -160,31 +158,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const totalTimelineHeight = yOffset;
         [timeAxisContainer, liberlColumn, crossbellColumn, ereboniaColumn, monthLinesOverlay].forEach(el => {
             if (el) el.style.height = `${totalTimelineHeight}px`;
-        });
-    }
-
-    function renderColorKey() {
-        if (!allGames || allGames.length === 0 || !colorKeyContainer) return;
-        colorKeyContainer.innerHTML = '';
-        const uniqueGamesForKey = [], titlesForKey = new Set();
-        allGames.forEach(game => {
-            if (!titlesForKey.has(game.englishTitle)) {
-                uniqueGamesForKey.push({ title: game.englishTitle, color: game.timelineColor });
-                titlesForKey.add(game.englishTitle);
-            }
-        });
-        uniqueGamesForKey.sort((a, b) => a.title.localeCompare(b.title));
-        uniqueGamesForKey.forEach(item => {
-            const keyItemDiv = document.createElement('div');
-            keyItemDiv.classList.add('color-key-item');
-            const swatchDiv = document.createElement('div');
-            swatchDiv.classList.add('color-key-swatch');
-            swatchDiv.style.backgroundColor = item.color;
-            const titleSpan = document.createElement('span');
-            titleSpan.textContent = item.title;
-            keyItemDiv.appendChild(swatchDiv);
-            keyItemDiv.appendChild(titleSpan);
-            colorKeyContainer.appendChild(keyItemDiv);
         });
     }
 

--- a/lore.html
+++ b/lore.html
@@ -26,10 +26,6 @@
         <div class="timeline-section">
             <h2>Lore Timeline</h2>
 
-            <div id="game-color-key-container">
-                <!-- Color key will be populated by JavaScript -->
-            </div>
-
             <div id="lore-timeline-main-container">
                 <div id="time-axis-container">
                     <!-- Time axis labels (years, months) will be populated by JavaScript -->

--- a/style.css
+++ b/style.css
@@ -310,31 +310,6 @@ main {
     margin-bottom: 1.5rem;
 }
 
-#game-color-key-container {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 10px 20px;
-    padding: 10px;
-    margin-bottom: 2rem;
-    background-color: rgba(0, 0, 0, 0.2);
-    border-radius: 8px;
-}
-
-.color-key-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    font-size: var(--font-size-sm);
-}
-
-.color-key-swatch {
-    width: 20px;
-    height: 20px;
-    border: 1px solid rgba(255, 255, 255, 0.5);
-    border-radius: 4px;
-}
-
 #lore-timeline-main-container {
     display: flex;
     position: relative; /* For absolute positioning of month lines container */


### PR DESCRIPTION
The color key on the Lore Timeline page was redundant as the game titles themselves are displayed on their respective timeline entries. This commit removes the key to simplify the UI.

Changes:
- Removed the color key container div from lore.html.
- Removed the renderColorKey() function and its call from lore-script.js.
- Removed unused CSS rules related to the color key from style.css.