### PR TITLE
Fix: Allow timeline to expand to a reasonable width

### DIFF
--- a/style.css
+++ b/style.css
@@ -307,12 +307,13 @@ main {
     font-family: 'Playfair Display', serif;
     font-size: var(--font-size-xxxl);
     color: var(--accent-gold);
-    margin-bottom: 1.5rem;
+    margin-bottom: 2rem; /* Increased from 1.5rem to restore space from removed key */
 }
 
 #lore-timeline-main-container {
     display: flex;
     position: relative; /* For absolute positioning of month lines container */
+    width: 100%; /* Ensure it uses available width within its parent */
 }
 
 #time-axis-container {


### PR DESCRIPTION
Set `width: 100%;` on the `#lore-timeline-main-container` to ensure it utilizes the available width within its parent. This allows the timeline columns to properly expand and fill the space, addressing the issue where the timeline became too narrow after the removal of the color key.