### PR TITLE
Fix: Ensure drop shadow visibility on slider items

### DIFF
--- a/style.css
+++ b/style.css
@@ -244,6 +244,7 @@ main {
 .slider-item {
     flex: 0 0 100%; /* Each item takes the full width of the slider viewport */
     box-sizing: border-box;
+    overflow: visible; /* Allow box-shadow from child .game-entry to show */
     /* .game-entry styles will apply to the child div within .slider-item */
 }
 


### PR DESCRIPTION
- Added `overflow: visible;` to `.slider-item` in `style.css`. This allows the `box-shadow` of the child `.game-entry` (which represents the actual game card with the shadow) to be rendered outside the bounds of the `.slider-item` container, which was previously clipping it.

The `.game-entry-slider` already had `overflow-y: visible;` which is necessary for its children to overflow, but the individual `.slider-item` also needed to permit this for its own children.