### PR TITLE
Refactor: Adjust spacing for non-main timeline period text

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -351,8 +351,9 @@ document.addEventListener('DOMContentLoaded', () => {
                     periodDetailEl.innerHTML = lineText;
                     periodTextContainer.appendChild(periodDetailEl);
 
-                    // Position this text container right below its corresponding box
-                    periodTextContainer.style.top = `${topPosition + entryHeight + 5}px`; // 5px spacing below the box
+                    // Adjust spacing based on whether it's a main display or not
+                    const spacing = period.isMain ? 5 : 2; // 5px for main, 2px for others
+                    periodTextContainer.style.top = `${topPosition + entryHeight + spacing}px`;
 
                     targetColumn.appendChild(periodTextContainer); // Add text container to the column
 


### PR DESCRIPTION
- Modified `lore-script.js` to reduce the vertical spacing between a game box and its associated text for non-main periods of multi-period games (Sky 3rd, CSII, Reverie).
- Spacing for these non-main period text elements is now 2px (down from 5px).
- Main period text for these games, and the text for CSIV, retain the original 5px spacing to maintain prominence.