### PR TITLE
Feat: Implement full-screen hero section on home page

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,8 +22,9 @@
         </nav>
     </header>
 
-    <main class="main-home">
-        <div class="hero-section">
+    <main class="home-hero">
+        <div class="hero-background-image"></div>
+        <div class="hero-content">
             <h2 class="hero-tagline">Explore the intricate timeline and lore of the Trails saga.</h2>
             <div class="hero-actions">
                 <a href="games.html" class="btn btn-hero">View the Releases</a>

--- a/style.css
+++ b/style.css
@@ -196,12 +196,48 @@ main {
 }
 
 /* Specific overrides for the main element on the home page */
-.main-home {
+.home-hero { /* Renamed from .main-home to match HTML */
     padding: 0;
     max-width: none;
     min-width: 0;
-    /* flex-grow: 1; is inherited and correct */
+    flex-grow: 1; /* Takes up full available height in the body flex container */
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    position: relative; /* Anchor for absolute positioned background */
+    overflow: hidden; /* Ensures blurred edges of background don't cause scrollbars */
 }
+
+.hero-background-image {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background-image: url('assets/hero/trails-into-reverie.jpg'); /* Placeholder */
+    background-size: cover;
+    background-position: center;
+    filter: blur(4px) brightness(0.7); /* Blur and darken */
+    z-index: 1; /* Behind content */
+}
+
+.hero-content {
+    position: relative;
+    z-index: 2; /* Above background */
+    text-align: center;
+    padding: 2rem; /* Add some padding around content */
+    color: var(--text-primary);
+    /* Styles from .hero-section, .hero-tagline, .hero-actions, .hero-intro will apply to children */
+    /* Add text shadow for readability if not already handled by children */
+    text-shadow: 1px 1px 4px rgba(0,0,0,0.5); /* General text shadow for content */
+}
+
+/* Ensure child elements within .hero-content also have a higher z-index if they use absolute/relative positioning */
+.hero-content > * {
+    position: relative;
+    z-index: 3; /* Or just ensure they don't have a z-index that puts them behind .hero-background-image */
+}
+
 
 #game-timeline-container { display: flex; flex-direction: column; gap: 3rem; }
 .game-entry {


### PR DESCRIPTION
- Restructured index.html to support a two-layer design with a background image and foreground content.
- Added CSS for .home-hero, .hero-background-image, and .hero-content to create a full-screen, blurred background effect with centered, readable text on top.
- Used 'assets/hero/trails-into-reverie.jpg' as a placeholder background image.