### PR TITLE
Fixed shadow clipping and made transition smoother for variants

### DIFF
--- a/script.js
+++ b/script.js
@@ -500,6 +500,15 @@ document.addEventListener('DOMContentLoaded', () => {
         function updateSlidePosition() {
             // The 2rem gap is defined in CSS for .slider-content-strip gap
             contentStrip.style.transform = `translateX(calc(-${currentIndex} * (100% + 2rem)))`;
+
+            // Fade out non-active items, fade in active item
+            const items = contentStrip.children;
+            for (let i = 0; i < items.length; i++) {
+                const item = items[i];
+                // Set opacity to 1 for the current item, 0 for others.
+                // The transition is handled by CSS.
+                item.style.opacity = i === currentIndex ? '1' : '0';
+            }
         }
 
         function updateDesktopButtonState() {

--- a/style.css
+++ b/style.css
@@ -357,7 +357,7 @@ main {
 }
 
 .game-entry-slider {
-    overflow-x: hidden;  /* This continues to hide the other slides horizontally */
+    overflow-x: visible; /* This allows box-shadows to appear */
     overflow-y: visible; /* This allows the vertical box-shadow to be displayed */
     position: relative; /* Optional: if it needs to be a positioning context for something else inside, though not strictly necessary for current setup */
     /* width: 100%; Ensure it takes the space of a normal game-entry.
@@ -379,6 +379,7 @@ main {
     box-sizing: border-box;
     overflow: visible; /* Allow box-shadow from child .game-entry to show */
     padding-bottom: 20px; /* Add space for the shadow to render */
+    transition: opacity 0.5s ease-in-out;
     /* .game-entry styles will apply to the child div within .slider-item */
 }
 


### PR DESCRIPTION
Changes made:
- Setting `overflow-x: visible` on the slider container to prevent clipping.
- Adding a CSS opacity transition to the slider items.
- Updating the JavaScript to set the opacity of non-active slides to 0.

This combination creates a smooth fade-and-slide transition for the release variants and ensures that shadows are no longer clipped.