### PR TITLE
feat: Add tabbed interface to Lore page

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -1,4 +1,72 @@
 document.addEventListener('DOMContentLoaded', () => {
+    // --- Tabbed Interface Logic ---
+    const tabsContainer = document.querySelector('.lore-tabs');
+    if (tabsContainer) {
+        const tabLinks = tabsContainer.querySelectorAll('.tab-link');
+        const tabContents = document.querySelectorAll('.tab-content');
+
+        // Immediately show the default active tab content on page load
+        const initialActiveContent = document.querySelector('.tab-content.active');
+        if (initialActiveContent) {
+            // Add 'show' class to make it visible with fade-in effect
+            // Use a timeout to ensure the transition is applied after initial render
+            setTimeout(() => {
+                initialActiveContent.classList.add('show');
+            }, 10);
+        }
+
+        tabsContainer.addEventListener('click', (e) => {
+            const clickedTab = e.target.closest('.tab-link');
+            if (!clickedTab) return;
+
+            e.preventDefault();
+
+            // Do nothing if the clicked tab is already active
+            if (clickedTab.classList.contains('active')) {
+                return;
+            }
+
+            const targetTabContentId = clickedTab.dataset.tab;
+            const targetTabContent = document.getElementById(targetTabContentId);
+
+            const currentActiveTab = tabsContainer.querySelector('.active');
+            const currentActiveContent = document.querySelector('.tab-content.active');
+
+            // Switch active state on tabs
+            if (currentActiveTab) {
+                currentActiveTab.classList.remove('active');
+            }
+            clickedTab.classList.add('active');
+
+            // Animate content transition
+            if (currentActiveContent && targetTabContent) {
+                currentActiveContent.classList.remove('show'); // Start fade-out
+
+                // Listen for the fade-out to finish
+                currentActiveContent.addEventListener('transitionend', function handler(event) {
+                    // Ensure we're listening for the opacity transition specifically
+                    if (event.propertyName !== 'opacity') return;
+
+                    // Clean up the old content
+                    currentActiveContent.classList.remove('active');
+
+                    // Show the new content
+                    targetTabContent.classList.add('active'); // Makes it display: block
+
+                    // Use a timeout to ensure the 'active' class is applied and rendered
+                    // before the 'show' class is added, triggering the fade-in transition.
+                    setTimeout(() => {
+                        targetTabContent.classList.add('show');
+                    }, 10); // A small delay is enough
+
+                    // Remove the event listener to prevent it from firing multiple times
+                    currentActiveContent.removeEventListener('transitionend', handler);
+                });
+            }
+        });
+    }
+
+
     const pixelsPerMonthVertical = 22; // Adjusted for better density
     let allGames = [];
     let minDate, maxDate;

--- a/lore.html
+++ b/lore.html
@@ -22,42 +22,54 @@
         </nav>
     </header>
 
+    <nav class="arc-navigation lore-tabs">
+        <a href="#" class="tab-link active" data-tab="timeline-view">Timeline</a>
+        <a href="#" class="tab-link" data-tab="map-view">Map</a>
+    </nav>
+
     <main>
-        <div class="timeline-section">
-            <h2>Lore Timeline</h2>
+        <div id="timeline-view" class="tab-content active">
+            <div class="timeline-section">
+                <h2>Lore Timeline</h2>
 
-            <p style="font-size: 0.9em; font-style: italic; text-align: center; margin-bottom: 15px;">
-                The timeline presented below is based on information sourced from in-game scripts and the <a href="https://kiseki.fandom.com/wiki/Timeline_of_Zemurian_history" target="_blank" rel="noopener noreferrer">Kiseki Wiki</a>.<br>Best viewed on desktop; small screens may require horizontal scrolling.
-            </p>
+                <p style="font-size: 0.9em; font-style: italic; text-align: center; margin-bottom: 15px;">
+                    The timeline presented below is based on information sourced from in-game scripts and the <a href="https://kiseki.fandom.com/wiki/Timeline_of_Zemurian_history" target="_blank" rel="noopener noreferrer">Kiseki Wiki</a>.<br>Best viewed on desktop; small screens may require horizontal scrolling.
+                </p>
 
-            <div class="lore-timeline-scroll-wrapper">
-                <div id="lore-timeline-main-container">
-                    <div id="time-axis-container">
-                        <!-- Time axis labels (years, months) will be populated by JavaScript -->
-                </div>
-                <div id="game-columns-container">
-                    <div class="timeline-arc-column" id="liberl-arc-column">
-                        <h3>Liberl Arc</h3>
-                        <div class="game-entries-area">
-                            <!-- Liberl Arc game entries will be populated by JavaScript -->
+                <div class="lore-timeline-scroll-wrapper">
+                    <div id="lore-timeline-main-container">
+                        <div id="time-axis-container">
+                            <!-- Time axis labels (years, months) will be populated by JavaScript -->
+                        </div>
+                        <div id="game-columns-container">
+                            <div class="timeline-arc-column" id="liberl-arc-column">
+                                <h3>Liberl Arc</h3>
+                                <div class="game-entries-area">
+                                    <!-- Liberl Arc game entries will be populated by JavaScript -->
+                                </div>
+                            </div>
+                            <div class="timeline-arc-column" id="crossbell-arc-column">
+                                <h3>Crossbell Arc</h3>
+                                <div class="game-entries-area">
+                                    <!-- Crossbell Arc game entries will be populated by JavaScript -->
+                                </div>
+                            </div>
+                            <div class="timeline-arc-column" id="erebonia-arc-column">
+                                <h3>Erebonia Arc</h3>
+                                <div class="game-entries-area">
+                                    <!-- Erebonia Arc game entries will be populated by JavaScript -->
+                                </div>
+                            </div>
+                            <!-- Horizontal month lines will be overlaid/drawn by JavaScript -->
                         </div>
                     </div>
-                    <div class="timeline-arc-column" id="crossbell-arc-column">
-                        <h3>Crossbell Arc</h3>
-                        <div class="game-entries-area">
-                            <!-- Crossbell Arc game entries will be populated by JavaScript -->
-                        </div>
-                    </div>
-                    <div class="timeline-arc-column" id="erebonia-arc-column">
-                        <h3>Erebonia Arc</h3>
-                        <div class="game-entries-area">
-                            <!-- Erebonia Arc game entries will be populated by JavaScript -->
-                        </div>
-                    </div>
-                    <!-- Horizontal month lines will be overlaid/drawn by JavaScript -->
                 </div>
             </div>
         </div>
+
+        <div id="map-view" class="tab-content">
+            <h2 style="text-align: center; margin-top: 50px;">Map Area</h2>
+            <p style="text-align: center;">This section is currently under construction. Please check back later for an interactive map of Zemuria.</p>
         </div>
     </main>
 

--- a/style.css
+++ b/style.css
@@ -211,6 +211,34 @@ footer a:hover {
 }
 
 
+/* Lore Page Tab Navigation */
+.lore-tabs {
+    /* The .arc-navigation class provides the base style. */
+    /* These rules adjust it for the Lore page context. */
+    border-top: none; /* The header's bottom border serves as the top line */
+    border-bottom: 1px solid rgba(233, 213, 161, 0.15); /* Add a bottom border to separate from main content */
+    padding-top: 0.4rem;
+    padding-bottom: 0.4rem;
+}
+
+/* Tab Content Styling */
+.tab-content {
+    display: none; /* Hidden by default */
+    opacity: 0;
+    transition: opacity 0.3s ease-in-out;
+}
+
+/* The 'active' class makes the container visible but still transparent */
+.tab-content.active {
+    display: block;
+}
+
+/* The 'show' class makes the content opaque, triggering the fade-in */
+.tab-content.show {
+    opacity: 1;
+}
+
+
 /* --- Arc Headers --- */
 .arc-header {
     text-align: center;


### PR DESCRIPTION
Refactors the `lore.html` page to incorporate a tabbed interface, allowing you to switch between the existing "Timeline" view and a new placeholder "Map" view.

- Implements a new sub-navigation bar for "Timeline" and "Map" tabs, styled to match the existing `.arc-navigation`.
- Restructures the main content into two containers, one for each tab's view.
- Adds JavaScript logic in `lore-script.js` to handle tab switching with a smooth fade-in/fade-out animation.
- The "Timeline" view is active by default.