### PR TITLE
feat: Make map infobox responsive

### DIFF
--- a/style.css
+++ b/style.css
@@ -1064,15 +1064,15 @@ main {
     border-radius: 8px;
     box-shadow: 0 8px 30px rgba(0, 0, 0, 0.6);
     color: var(--text-primary);
-    padding: 0.75rem 1.5rem; /* Reduced top/bottom padding */
-    width: max-content; /* Let content decide the width */
+    padding: 0.75rem 1.5rem;
+    width: 500px;
     max-width: 90vw;
     opacity: 0;
     transform: scale(0.95);
     transition: opacity 0.3s ease, transform 0.3s ease;
-    pointer-events: none; /* Hidden by default, cannot be interacted with */
-    display: flex; /* Make it a flex container */
-    flex-direction: column; /* Stack children vertically */
+    pointer-events: none;
+    display: flex;
+    flex-direction: column;
 }
 
 #map-infobox.active {
@@ -1161,14 +1161,16 @@ main {
 /* --- New Infobox Games Grid Styling --- */
 .infobox-games {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.5rem;
     justify-content: center;
-    height: 220px;
+    height: auto;
     margin: 0;
 }
 
 .infobox-games img {
-    height: 100%;
+    height: auto;
+    max-height: 180px;
     width: auto;
     border-radius: 4px;
     box-shadow: 0 2px 5px rgba(0,0,0,0.4);
@@ -1178,5 +1180,23 @@ main {
 @media (min-width: 1200px) {
     .infobox-header h2 {
         font-size: 2.5rem; /* Cap the font size */
+    }
+}
+
+/* --- Responsive Infobox for smaller screens --- */
+@media (max-width: 768px) {
+    #map-infobox {
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        width: 90vw; /* Take up more of the screen */
+    }
+
+    .infobox-header h2 {
+        font-size: 1.5rem; /* Reduce title font size */
+    }
+
+    #map-infobox.active {
+        transform: translate(-50%, -50%) scale(1); /* Adjust active transform */
     }
 }


### PR DESCRIPTION
The map infobox was previously too large on smaller screens. This change introduces several improvements to make it responsive:

- The infobox width is now fixed on larger screens but scales with the viewport on smaller screens.
- The grid of game images within the infobox now wraps to multiple lines to prevent horizontal overflow.
- A media query has been added to center the infobox and adjust typography on screens narrower than 768px, providing a better mobile experience.