### PR TITLE
fix: Make timeline responsive and fix scrolling on small screens

### DIFF
--- a/style.css
+++ b/style.css
@@ -263,9 +263,11 @@ main {
     flex-grow: 1;
 }
 
-/* Specific overrides for the main element on the lore page */
-.lore-page main {
-    max-width: 1700px;
+/* Specific overrides for the main element on the lore page on larger screens */
+@media (min-width: 901px) {
+    .lore-page main {
+        max-width: 1700px;
+    }
 }
 
 /* Specific overrides for the main element on the home page */


### PR DESCRIPTION
This commit fixes a regression introduced in the previous commit where the ability to scroll horizontally on smaller screens was removed.

The issue was caused by a CSS rule that overrode the mobile styles for the main content area. This has been resolved by wrapping the desktop-specific rule in a media query (`@media (min-width: 901px)`), ensuring it only applies to larger screens.

This change restores the intended scrolling behavior on smaller screens while preserving the responsive layout on larger screens.