### PR TITLE
Fix responsive horizontal scrolling for Lore Timeline

### DIFF
--- a/lore.html
+++ b/lore.html
@@ -11,7 +11,7 @@
     <link rel="icon" href="assets/favicon.png" type="image/png">
     <script src="lore-script.js" defer></script>
 </head>
-<body class="lore-page">
+<body>
 
     <header>
         <h1>Zemurian Atlas</h1>
@@ -26,7 +26,7 @@
         </nav>
     </header>
 
-    <main>
+    <main class="lore-page">
         <div id="timeline-view" class="tab-content active">
             <div class="timeline-section">
                 <h2>Lore Timeline</h2>

--- a/style.css
+++ b/style.css
@@ -256,15 +256,11 @@ footer a:hover {
 
 /* --- Main Timeline Layout --- */
 main {
-    padding: 0rem;
+    padding: 0;
     max-width: 1300px;
     margin: 0 auto;
     min-width: 600px; /* Ensure enough space for slider arrows + content */
     flex-grow: 1;
-}
-/* Specific overrides for the main element on the lore page */
-.lore-page main {
-    max-width: 1700px;
 }
 
 /* Specific overrides for the main element on the home page */
@@ -473,8 +469,13 @@ main {
     /* overflow-x: auto; */ /* Moved to .lore-timeline-scroll-wrapper */
 }
 
+.timeline-section,
+.full-width-section {
+    padding: 2rem 1rem;
+}
+
 .lore-timeline-scroll-wrapper {
-    overflow-x: auto;
+    /* overflow-x: auto; */ /* Replaced by media query */
     width: 100%; /* Ensures the wrapper itself doesn't overflow the page layout if content is narrower */
 }
 
@@ -658,6 +659,11 @@ main {
 
 /* Tooltip styling removed as browser default tooltips are not used. */
 
+@media (max-width: 1700px) {
+    .lore-timeline-scroll-wrapper {
+        overflow-x: auto;
+    }
+}
 
 @media (max-width: 900px) {
     main {


### PR DESCRIPTION
Moved the `lore-page` class from the `body` to the `main` tag in `lore.html` to better scope the page-specific styles.

In `style.css`:
- Removed the redundant `.lore-page main` rule.
- Changed `main` element padding to 0 and applied it directly to content sections (`.timeline-section`, `.full-width-section`) for better layout control.
- Made the `.lore-timeline-scroll-wrapper` horizontally scrollable only on screens narrower than 1700px using a media query, preventing unnecessary scrollbars on wider displays.