### PR TITLE
Fix: Scope overflow-x rule to releases page

### DIFF
--- a/games.html
+++ b/games.html
@@ -11,7 +11,7 @@
     <link rel="icon" href="assets/favicon.png" type="image/png">
     <script src="script.js" defer></script>
 </head>
-<body>
+<body class="releases-page">
 
     <header>
         <h1>Zemurian Atlas</h1>

--- a/style.css
+++ b/style.css
@@ -32,7 +32,11 @@ body {
     display: flex;
     flex-direction: column;
     min-height: 100vh;
-    overflow-x: hidden; /* Prevent horizontal scrollbars from slider overflow */
+}
+
+/* Prevent horizontal scrollbars from slider overflow */
+.releases-page {
+    overflow-x: hidden;
 }
 
 /* Apply background only to the home page's body */


### PR DESCRIPTION
This change fixes a responsive layout bug on the Lore Timeline by correctly scoping a CSS overflow rule. The timeline should be fully visible on wide screens and horizontally scrollable on medium screens, which was being prevented by a global style.

The `overflow-x: hidden;` property has been moved from the global `body` selector to a new `.releases-page` class, which is applied to the `<body>` of `games.html`.