### PR TITLE
feat: Add Calvard Arc column to Lore Timeline

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -84,6 +84,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const liberlColumn = document.getElementById('liberl-arc-column').querySelector('.game-entries-area');
     const crossbellColumn = document.getElementById('crossbell-arc-column').querySelector('.game-entries-area');
     const ereboniaColumn = document.getElementById('erebonia-arc-column').querySelector('.game-entries-area');
+    const calvardColumn = document.getElementById('calvard-arc-column').querySelector('.game-entries-area');
     
     let monthLinesOverlay; // Will be created and appended to gameColumnsContainer
 
@@ -290,7 +291,7 @@ document.addEventListener('DOMContentLoaded', () => {
         }
         
         const totalTimelineHeight = yOffset;
-        [timeAxisContainer, liberlColumn, crossbellColumn, ereboniaColumn, monthLinesOverlay].forEach(el => {
+        [timeAxisContainer, liberlColumn, crossbellColumn, ereboniaColumn, calvardColumn, monthLinesOverlay].forEach(el => {
             if (el) el.style.height = `${totalTimelineHeight}px`;
         });
     }
@@ -300,7 +301,7 @@ document.addEventListener('DOMContentLoaded', () => {
             console.warn("Cannot render game entries: missing data.");
             return;
         }
-        [liberlColumn, crossbellColumn, ereboniaColumn].forEach(col => { if (col) col.innerHTML = ''; });
+        [liberlColumn, crossbellColumn, ereboniaColumn, calvardColumn].forEach(col => { if (col) col.innerHTML = ''; });
 
         const minTotalMonths = dateToTotalMonths(minDate);
 
@@ -315,6 +316,7 @@ document.addEventListener('DOMContentLoaded', () => {
             if (game.arc === "Liberl Arc") targetColumn = liberlColumn;
             else if (game.arc === "Crossbell Arc") targetColumn = crossbellColumn;
             else if (game.arc === "Erebonia Arc" || game.englishTitle === "Trails into Reverie") targetColumn = ereboniaColumn;
+            else if (game.arc === "Calvard Arc") targetColumn = calvardColumn;
             else {
                 console.warn(`Game "${game.englishTitle}" arc "${game.arc}" unassigned. Skipping rendering.`);
                 return;

--- a/lore.html
+++ b/lore.html
@@ -59,6 +59,12 @@
                                     <!-- Erebonia Arc game entries will be populated by JavaScript -->
                                 </div>
                             </div>
+                            <div class="timeline-arc-column" id="calvard-arc-column">
+                                <h3>Calvard Arc</h3>
+                                <div class="game-entries-area">
+                                    <!-- Calvard Arc game entries will be populated by JavaScript -->
+                                </div>
+                            </div>
                             <!-- Horizontal month lines will be overlaid/drawn by JavaScript -->
                         </div>
                     </div>

--- a/style.css
+++ b/style.css
@@ -486,7 +486,8 @@ main {
 #lore-timeline-main-container {
     display: flex;
     position: relative; /* For absolute positioning of month lines container */
-    width: 1200px;
+    width: 100%;
+    min-width: 1600px;
 }
 
 #time-axis-container {


### PR DESCRIPTION
This commit introduces the Calvard Arc as a fourth, fully functional column to the lore timeline.

Key changes:
- **`lore.html`**: Added the HTML structure for the `calvard-arc-column` within the main container, mirroring the existing arc columns.
- **`lore-script.js`**:
    - Created a new constant to select the Calvard column.
    - Updated the game routing logic to populate the new column with games belonging to the "Calvard Arc".
    - Included the new column in the dynamic height calculations and content-clearing operations to ensure proper rendering and state management.
- **`style.css`**:
    - Made the `#lore-timeline-main-container` responsive by changing its fixed width to `100%` with a `min-width` of `1600px`. This accommodates the fourth column while ensuring the layout is flexible and well-spaced on larger screens.