### PR TITLE
feat: Make lore timeline width responsive

### DIFF
--- a/lore.html
+++ b/lore.html
@@ -26,7 +26,7 @@
         </nav>
     </header>
 
-    <main>
+    <main class="main-lore">
         <div id="timeline-view" class="tab-content active">
             <div class="timeline-section">
                 <h2>Lore Timeline</h2>

--- a/style.css
+++ b/style.css
@@ -256,6 +256,8 @@ footer a:hover {
 
 /* --- Main Timeline Layout --- */
 main {
+    width: 100%;
+    box-sizing: border-box;
     padding: 0rem;
     max-width: 1300px;
     margin: 0 auto;
@@ -269,6 +271,11 @@ main {
     max-width: none;
     min-width: 0;
     /* flex-grow: 1; is inherited and correct */
+}
+
+/* On the lore page, allow the main container to expand to the timeline's full width */
+.main-lore {
+    max-width: 1600px;
 }
 
 #game-timeline-container { display: flex; flex-direction: column; gap: 3rem; }


### PR DESCRIPTION
The lore timeline's main container is now responsive.

- On viewports wider than 1600px, the main content area will expand up to 1600px, allowing the entire timeline to be displayed without horizontal scrolling.
- On viewports narrower than 1600px, the main content area will shrink with the viewport, and the timeline's existing horizontal scrollbar will be used.

This was achieved by adding a specific class to the lore page's main element and updating the CSS to apply a larger max-width. A general improvement was also made to the main element's CSS to ensure it is always constrained by the viewport width.