### PR TITLE
feat(lore): Make map default and persist tab selection

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -4,21 +4,14 @@ document.addEventListener('DOMContentLoaded', () => {
     // --- Tabbed Interface Logic ---
     const tabsContainer = document.querySelector('.lore-tabs');
     if (tabsContainer) {
-        // Restore last selected tab from localStorage
-        const savedTabId = localStorage.getItem('loreLastTab');
-        if (savedTabId) {
-            // Clear default 'active' classes
-            const currentActiveTab = document.querySelector('.lore-tabs .active');
-            const currentActiveContent = document.querySelector('.tab-content.active');
-            if (currentActiveTab) currentActiveTab.classList.remove('active');
-            if (currentActiveContent) currentActiveContent.classList.remove('active');
+        // Determine the tab to show: saved tab or default to 'map-view'.
+        const tabIdToShow = localStorage.getItem('loreLastTab') || 'map-view';
 
-            // Apply 'active' to the saved tab and its content
-            const newActiveTab = document.querySelector(`.tab-link[data-tab="${savedTabId}"]`);
-            const newActiveContent = document.getElementById(savedTabId);
-            if (newActiveTab) newActiveTab.classList.add('active');
-            if (newActiveContent) newActiveContent.classList.add('active');
-        }
+        // Apply 'active' to the determined tab and its content.
+        const tabLinkToShow = document.querySelector(`.tab-link[data-tab="${tabIdToShow}"]`);
+        const contentToShow = document.getElementById(tabIdToShow);
+        if (tabLinkToShow) tabLinkToShow.classList.add('active');
+        if (contentToShow) contentToShow.classList.add('active');
 
         // Check if the map is the active tab on load (either default or from storage) and initialize it
         const initialActiveContent = document.querySelector('.tab-content.active');
@@ -61,7 +54,6 @@ document.addEventListener('DOMContentLoaded', () => {
                     currentActiveContent.classList.remove('active');
                     targetTabContent.classList.add('active');
                     setTimeout(() => targetTabContent.classList.add('show'), 10);
-                    currentActiveContent.removeEventListener('transitionend', handler);
                 }, { once: true }); // Use { once: true } for cleaner event handling
             }
         });

--- a/lore.html
+++ b/lore.html
@@ -21,8 +21,8 @@
             <a href="lore.html" class="active">Lore</a>
         </nav>
         <nav class="arc-navigation lore-tabs">
+            <a href="#" class="tab-link" data-tab="map-view">Map</a>
             <a href="#" class="tab-link" data-tab="timeline-view">Timeline</a>
-            <a href="#" class="tab-link active" data-tab="map-view">Map</a>
         </nav>
     </header>
 
@@ -72,7 +72,7 @@
             </div>
         </div>
 
-        <div id="map-view" class="tab-content active">
+        <div id="map-view" class="tab-content">
             <div class="full-width-section">
                 <h2>Interactive Map</h2>
                 <p style="font-size: 0.9em; font-style: italic; text-align: center; margin-bottom: 15px;">


### PR DESCRIPTION
This commit introduces two changes to the Lore page:

1.  The default view is now the "Map" tab instead of the "Timeline" tab.
2.  Your selected tab is now saved to `localStorage`. When you re-visit the Lore page, your last selected tab will be displayed.

This was implemented by removing the hardcoded `active` state from the HTML and adding logic to `lore-script.js` to manage the tab state dynamically. The script now defaults to 'map-view' if no preference is found in `localStorage`.

Additionally, this commit addresses feedback on the initial implementation:
- The order of the tabs has been swapped to "Map", then "Timeline".
- A "flash of incorrect active tab" has been fixed by removing the default active state from the HTML, so the script can apply the correct state from the start.
- The JavaScript has been refactored for clarity and to remove a minor redundancy in the event listener logic.