### PR TITLE
feat: Make Daybreak timeline text black

### DIFF
--- a/lore-script.js
+++ b/lore-script.js
@@ -371,7 +371,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 const gameEntryDiv = document.createElement('div');
                 gameEntryDiv.className = 'game-entry-box';
                 gameEntryDiv.style.backgroundColor = game.timelineColor;
-                gameEntryDiv.style.color = game.englishTitle === "Trails in the Sky SC" ? '#000000' : '#FFFFFF';
+                gameEntryDiv.style.color = game.englishTitle === "Trails in the Sky SC" || game.englishTitle === "Trails through Daybreak" ? '#000000' : '#FFFFFF';
                 gameEntryDiv.style.top = `${topPosition + 2}px`; // -1 for border adjustment, +3 for shift
                 gameEntryDiv.style.height = `${entryHeight}px`;
                 gameEntryDiv.style.width = '90%';


### PR DESCRIPTION
This change updates the timeline rendering logic to set the text color for 'Trails through Daybreak' to black, similar to 'Trails in the Sky SC', to improve readability against its light-colored background.