### PR TITLE
fix(css): Make map infobox art grid responsive

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -773,7 +773,10 @@ body.home-page::before {
     display: flex;
     gap: 0.5rem;
     justify-content: center;
-    height: 220px;
+    align-items: flex-start; /* Better alignment for varying aspect ratios */
+    height: 28vh; /* Responsive height based on viewport */
+    min-height: 160px; /* Minimum height for smaller screens */
+    max-height: 220px; /* Maximum height to match original design on large screens */
     margin: 0;
 }
 .infobox-games img {


### PR DESCRIPTION
The previous styling for the `.infobox-games` container used a fixed height of `220px`. This prevented the art grid from scaling down on smaller screens, causing layout issues in the map infobox.

This change replaces the fixed height with a responsive approach:
- `height` is now based on the viewport height (`28vh`), allowing it to scale with the screen size.
- `max-height` is set to `220px` to preserve the original appearance on larger screens.
- `min-height` is set to `160px` to ensure the art grid remains usable on very small screens.
- `align-items: flex-start` is added to better handle the alignment of game art, which may have varying aspect ratios.