### PR TITLE
Fix CSS bugs on mobile and desktop layouts

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -91,7 +91,7 @@ footer a:hover {
 main {
     width: 100%;
     box-sizing: border-box;
-    padding: 0rem;
+    padding: 0 1rem;
     max-width: 1300px;
     margin: 0 auto;
     min-width: 600px; /* Ensure enough space for slider arrows + content */
@@ -807,6 +807,14 @@ body.home-page::before {
         margin-right: 0;
         box-sizing: border-box;
         overflow-x: hidden; /* Contain horizontal overflow from children like sliders */
+    }
+
+    /* Fix for mobile scroll and shadow clipping issues */
+    .slider-display-area {
+        margin-bottom: 0;
+    }
+    .slider-item {
+        padding-bottom: 0;
     }
     .desktop-only {
         display: none !important;


### PR DESCRIPTION
This commit fixes two CSS bugs:

1.  A nested vertical scrollbar on the mobile layout of the releases page is removed by overriding desktop-specific margin and padding styles that were causing a minor overflow.
2.  Missing horizontal padding on the releases page, which caused content to touch the screen edges on medium-width desktop screens, is fixed by adding padding to the main content element.

The changes ensure that visual elements like drop shadows are not clipped, preserving the existing design.