### PR TITLE
feat: Update variant display for Trails in the Sky

### DIFF
--- a/src/js/map.js
+++ b/src/js/map.js
@@ -171,9 +171,14 @@ export function initMapPage() {
         // Populate Games View
         const gamesInRegion = mapGamesData.filter(game => (region.games || []).includes(game.id));
         gamesViewEl.innerHTML = gamesInRegion.length > 0
-            ? `<div class="map-infobox-games-grid">${gamesInRegion.map(game => `
-                <img src="assets/grid/${game.assetName}.jpg" alt="${game.englishTitle}" title="${game.englishTitle}" class="map-infobox-game-art">
-              `).join('')}</div>`
+            ? `<div class="map-infobox-games-grid">${gamesInRegion.map(game => {
+                let assetName = game.assetName;
+                // Per user request, show the 1st Chapter variant grid art for the Liberl infobox.
+                if (game.id === 'trails-in-the-sky' && game.variants && game.variants.length > 0) {
+                    assetName = game.variants[0].assetName;
+                }
+                return `<img src="assets/grid/${assetName}.jpg" alt="${game.englishTitle}" title="${game.englishTitle}" class="map-infobox-game-art">`;
+              }).join('')}</div>`
             : '<p style="font-size: 0.8em; color: #999;">No specific games are primarily set in this region.</p>';
 
         // Populate Lore View

--- a/src/js/releases.js
+++ b/src/js/releases.js
@@ -343,7 +343,9 @@ export function initReleasesPage() {
                 if (game.variants && game.variants.length > 0) {
                     const sliderDisplayArea = document.createElement('div');
                     sliderDisplayArea.className = 'slider-display-area';
-                    sliderDisplayArea.setAttribute('data-current-index', '0');
+                    // Default to the 1st Chapter variant for the original Sky, per user request.
+                    const initialIndex = game.id === 'trails-in-the-sky' ? '1' : '0';
+                    sliderDisplayArea.setAttribute('data-current-index', initialIndex);
 
                     const gameEntrySlider = document.createElement('div');
                     gameEntrySlider.className = 'game-entry-slider';


### PR DESCRIPTION
This commit implements two specific display changes for the "Trails in the Sky" game and its "1st Chapter" variant, as requested.

- On the Releases page, the slider for "Trails in the Sky" now defaults to showing the "1st Chapter" variant instead of the original game. This is achieved by setting the initial index of the slider to '1' for this specific game ID in `releases.js`.

- On the Map page, the infobox for the Liberl region now displays the grid art for the "1st Chapter" variant. This is handled by adding a condition in `map.js` to use the variant's asset name when rendering the game grid for "Trails in the Sky".

These changes are targeted and do not affect any other games or variants on the site.