### PR TITLE
Fix: favicon path

### DIFF
--- a/games.html
+++ b/games.html
@@ -24,8 +24,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:ital,wght@1,700&display=swap" rel="stylesheet">
-    <link rel="icon" href="/favicon.png" sizes="16x16 32x32" type="image/png">
-    <link rel="apple-touch-icon" href="/favicon.png">
+    <link rel="icon" href="favicon.png" sizes="16x16 32x32" type="image/png">
+    <link rel="apple-touch-icon" href="favicon.png">
     <link rel="manifest" href="/site.webmanifest">
     <script src="src/js/main.js" type="module" defer></script>
 </head>

--- a/index.html
+++ b/index.html
@@ -24,8 +24,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:ital,wght@1,700&display=swap" rel="stylesheet">
-    <link rel="icon" href="/favicon.png" sizes="16x16 32x32" type="image/png">
-    <link rel="apple-touch-icon" href="/favicon.png">
+    <link rel="icon" href="favicon.png" sizes="16x16 32x32" type="image/png">
+    <link rel="apple-touch-icon" href="favicon.png">
     <link rel="manifest" href="/site.webmanifest">
     <script src="src/js/main.js" type="module" defer></script>
 </head>

--- a/map.html
+++ b/map.html
@@ -24,8 +24,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:ital,wght@1,700&display=swap" rel="stylesheet">
-    <link rel="icon" href="/favicon.png" sizes="16x16 32x32" type="image/png">
-    <link rel="apple-touch-icon" href="/favicon.png">
+    <link rel="icon" href="favicon.png" sizes="16x16 32x32" type="image/png">
+    <link rel="apple-touch-icon" href="favicon.png">
     <link rel="manifest" href="/site.webmanifest">
     <script src="src/js/main.js" type="module" defer></script>
 </head>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -7,12 +7,12 @@
     "theme_color": "#000000",
     "icons": [
         {
-            "src": "/favicon.png",
+            "src": "favicon.png",
             "sizes": "192x192",
             "type": "image/png"
         },
         {
-            "src": "/favicon.png",
+            "src": "favicon.png",
             "sizes": "512x512",
             "type": "image/png"
         }

--- a/timeline.html
+++ b/timeline.html
@@ -24,8 +24,8 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:ital,wght@1,700&display=swap" rel="stylesheet">
-    <link rel="icon" href="/favicon.png" sizes="16x16 32x32" type="image/png">
-    <link rel="apple-touch-icon" href="/favicon.png">
+    <link rel="icon" href="favicon.png" sizes="16x16 32x32" type="image/png">
+    <link rel="apple-touch-icon" href="favicon.png">
     <link rel="manifest" href="/site.webmanifest">
     <script src="src/js/main.js" type="module" defer></script>
 </head>


### PR DESCRIPTION
The favicon path was previously absolute, which caused issues when the site was not hosted at the root of a domain. This change makes the path relative, fixing the issue.

I replaced all instances of `/favicon.png` with `favicon.png` in the following files:
- games.html
- index.html
- map.html
- site.webmanifest
- timeline.html