### PR TITLE
feat(map): delay fade-out of previous region's outline on hover

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -858,7 +858,7 @@ body.home-page::before {
     transition: fill 0.2s ease-in-out, stroke 0.2s ease-in-out, stroke-width 0.2s ease-in-out;
     cursor: pointer;
 }
-.region-path:hover {
+.region-path.is-hovered {
     fill: var(--region-highlight-color);
     stroke: var(--accent-gold);
     stroke-width: 5;

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -77,6 +77,48 @@ export function initMapPage() {
                 handleMapClick(clickedRegionId, e.clientX, e.clientY, e.pageX, e.pageY);
             });
 
+            // --- Custom Hover Logic ---
+            let lastHoveredPath = null;
+            let hoverTimeout = null;
+            const FADE_IN_DURATION = 200; // Must match the CSS transition duration
+
+            mapOverlay.addEventListener('mouseover', (e) => {
+                const currentPath = e.target.closest('.region-path');
+                if (!currentPath) return;
+
+                // If we're hovering over the same path, do nothing.
+                if (currentPath === lastHoveredPath) return;
+
+                // Clear any pending fade-out from a previous quick mouse-out/mouse-in.
+                clearTimeout(hoverTimeout);
+
+                // If there was a previously hovered path, it's time to start its fade-out.
+                // The key is that we *don't* do this instantly.
+                const pathToRemove = lastHoveredPath;
+
+                // Immediately apply the hover effect to the new path.
+                currentPath.classList.add('is-hovered');
+                lastHoveredPath = currentPath;
+
+                // If there was a previous path, schedule its hover-effect removal.
+                // This makes the old one only start fading *after* the new one has faded in.
+                if (pathToRemove) {
+                    hoverTimeout = setTimeout(() => {
+                        pathToRemove.classList.remove('is-hovered');
+                    }, FADE_IN_DURATION);
+                }
+            });
+
+            mapOverlay.addEventListener('mouseleave', () => {
+                // When the mouse leaves the entire map area, clear any pending fades
+                // and immediately remove the hover effect from the last known region.
+                clearTimeout(hoverTimeout);
+                if (lastHoveredPath) {
+                    lastHoveredPath.classList.remove('is-hovered');
+                    lastHoveredPath = null;
+                }
+            });
+
             // Remove the loading state
             mapContainer.classList.remove('is-loading');
         })


### PR DESCRIPTION
This change modifies the hover effect on the interactive map. Previously, when moving from one region to another, the old region's outline would fade out at the same time as the new one faded in.

This has been updated so that the previously-hovered region's outline only begins to fade out once the currently-hovered region's outline has fully faded in. This is achieved by replacing the CSS `:hover` pseudo-class with a JavaScript-controlled `.is-hovered` class and using `setTimeout` to orchestrate the animation timing.