### PR TITLE
fix(map): add 0.25s fade-out delay to region hover via CSS

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -856,12 +856,14 @@ body.home-page::before {
     stroke: transparent;
     stroke-width: 3;
     transition: fill 0.2s ease-in-out, stroke 0.2s ease-in-out, stroke-width 0.2s ease-in-out;
+    transition-delay: 0.25s;
     cursor: pointer;
 }
-.region-path.is-hovered {
+.region-path:hover {
     fill: var(--region-highlight-color);
     stroke: var(--accent-gold);
     stroke-width: 5;
+    transition-delay: 0s;
 }
 
 /*

--- a/src/js/map.js
+++ b/src/js/map.js
@@ -77,48 +77,6 @@ export function initMapPage() {
                 handleMapClick(clickedRegionId, e.clientX, e.clientY, e.pageX, e.pageY);
             });
 
-            // --- Custom Hover Logic ---
-            let lastHoveredPath = null;
-            let hoverTimeout = null;
-            const FADE_IN_DURATION = 200; // Must match the CSS transition duration
-
-            mapOverlay.addEventListener('mouseover', (e) => {
-                const currentPath = e.target.closest('.region-path');
-                if (!currentPath) return;
-
-                // If we're hovering over the same path, do nothing.
-                if (currentPath === lastHoveredPath) return;
-
-                // Clear any pending fade-out from a previous quick mouse-out/mouse-in.
-                clearTimeout(hoverTimeout);
-
-                // If there was a previously hovered path, it's time to start its fade-out.
-                // The key is that we *don't* do this instantly.
-                const pathToRemove = lastHoveredPath;
-
-                // Immediately apply the hover effect to the new path.
-                currentPath.classList.add('is-hovered');
-                lastHoveredPath = currentPath;
-
-                // If there was a previous path, schedule its hover-effect removal.
-                // This makes the old one only start fading *after* the new one has faded in.
-                if (pathToRemove) {
-                    hoverTimeout = setTimeout(() => {
-                        pathToRemove.classList.remove('is-hovered');
-                    }, FADE_IN_DURATION);
-                }
-            });
-
-            mapOverlay.addEventListener('mouseleave', () => {
-                // When the mouse leaves the entire map area, clear any pending fades
-                // and immediately remove the hover effect from the last known region.
-                clearTimeout(hoverTimeout);
-                if (lastHoveredPath) {
-                    lastHoveredPath.classList.remove('is-hovered');
-                    lastHoveredPath = null;
-                }
-            });
-
             // Remove the loading state
             mapContainer.classList.remove('is-loading');
         })


### PR DESCRIPTION
This change implements a 0.25-second delay for the fade-out effect on the interactive map's region outlines. When the user's mouse leaves a region, its outline will now linger for a moment before beginning to fade.

This is achieved purely through CSS by applying a `transition-delay` of `0.25s` to the base `.region-path` class and overriding it with a `0s` delay on the `.region-path:hover` pseudo-class. This ensures the fade-in effect remains immediate while the fade-out is delayed, providing a cleaner and more robust solution than the previous JavaScript-based approach.