### PR TITLE
feat: Randomize homepage background

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -186,7 +186,6 @@ main {
 =================================================================
 */
 body.home-page {
-    background-image: url('../../assets/home-bg.png');
     background-size: cover;
     background-position: center center;
     background-attachment: fixed;

--- a/src/js/home.js
+++ b/src/js/home.js
@@ -1,0 +1,52 @@
+/**
+ * @file home.js
+ * This file contains the logic for the home page of the Zemurian Atlas.
+ * Its primary function is to randomly select and apply a background image.
+ */
+
+/**
+ * An array of available background images for the homepage.
+ * These are all located in the `/assets/backgrounds/` directory.
+ */
+const backgroundImages = [
+    'azure.webp',
+    'azure2.png',
+    'azure3.png',
+    'azure4.webp',
+    'cold-steel-ii.webp',
+    'cold-steel-ii2.jpg',
+    'cold-steel-iii.jpg',
+    'cold-steel-iv.png',
+    'cold-steel.jpg',
+    'cold-steel2.png',
+    'cold-steel3.webp',
+    'cold-steel4.webp',
+    'daybreak.webp',
+    'sky-3rd.png',
+    'sky-remake.png',
+    'sky-sc.png',
+    'sky-sc2.png',
+    'sky-sc3.png',
+    'sky-sc4.png',
+    'sky.png',
+    'zero.webp',
+    'zero2.png',
+    'zero3.png'
+];
+
+/**
+ * Initializes the home page functionality.
+ * Specifically, it selects a random background image from the list
+ * and sets it as the background for the `<body>` element.
+ */
+export function initHomePage() {
+    // Select a random image from the array
+    const randomIndex = Math.floor(Math.random() * backgroundImages.length);
+    const selectedImage = backgroundImages[randomIndex];
+
+    // Construct the full path to the image
+    const imageUrl = `assets/backgrounds/${selectedImage}`;
+
+    // Apply the image to the body's background-image style
+    document.body.style.backgroundImage = `url('${imageUrl}')`;
+}

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -8,6 +8,7 @@ import { highlightActiveNav } from './lib/shared.js';
 import { initReleasesPage } from './releases.js';
 import { initTimelinePage } from './timeline.js';
 import { initMapPage } from './map.js';
+import { initHomePage } from './home.js';
 
 /**
  * Determines the current page and runs the appropriate initialization functions.
@@ -20,14 +21,15 @@ function route() {
     const currentPage = window.location.pathname.split('/').pop();
 
     // Route to page-specific logic
-    if (currentPage === 'games.html') {
+    if (currentPage === 'index.html' || currentPage === '') {
+        initHomePage();
+    } else if (currentPage === 'games.html') {
         initReleasesPage();
     } else if (currentPage === 'timeline.html') {
         initTimelinePage();
     } else if (currentPage === 'map.html') {
         initMapPage();
     }
-    // No specific JS needed for index.html other than the shared nav logic
 }
 
 // Run the router once the DOM is loaded


### PR DESCRIPTION
Implements a feature to randomly select and display a background image on the homepage from the `/assets/backgrounds` directory.

A new `src/js/home.js` module contains the logic for selecting and applying the random background. The main router in `src/js/main.js` now calls this logic for the homepage. The static `background-image` CSS rule was removed from `src/css/style.css` to allow the dynamic background to be displayed.

This ensures a new image is loaded on each visit while preserving the existing darkening and blur filter effects.