### PR TITLE
feat: Update map infobox button text to 'Show More Details'

### DIFF
--- a/src/js/map.js
+++ b/src/js/map.js
@@ -217,7 +217,7 @@ export function initMapPage() {
             toggleButton.className = 'map-infobox-toggle-btn';
 
             const updateButtonText = () => {
-                toggleButton.textContent = infoboxEl.classList.contains('show-lore-view') ? 'Show Game Art' : 'View Lore Details';
+                toggleButton.textContent = infoboxEl.classList.contains('show-lore-view') ? 'Show Game Art' : 'Show More Details';
             };
             toggleButton.addEventListener('click', (event) => {
                 event.stopPropagation();


### PR DESCRIPTION
Replaces the text 'View Lore Details' with 'Show More Details' on the button in the map's infobox. This change makes the button's purpose clearer to the user.