### PR TITLE
Refactor: Use root-relative links for the home page

### DIFF
--- a/games.html
+++ b/games.html
@@ -35,7 +35,7 @@
     <header>
         <h1>Zemurian Atlas</h1>
         <nav class="main-navigation">
-            <a href="index.html">Home</a>
+            <a href="./">Home</a>
             <a href="games.html" class="active">Releases</a>
             <a href="map.html">Map</a>
             <a href="timeline.html">Timeline</a>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <header>
         <h1>Zemurian Atlas</h1>
         <nav class="main-navigation">
-            <a href="index.html" class="active">Home</a>
+            <a href="./" class="active">Home</a>
             <a href="games.html">Releases</a>
             <a href="map.html">Map</a>
             <a href="timeline.html">Timeline</a>

--- a/map.html
+++ b/map.html
@@ -35,7 +35,7 @@
     <header>
         <h1>Zemurian Atlas</h1>
         <nav class="main-navigation">
-            <a href="index.html">Home</a>
+            <a href="./">Home</a>
             <a href="games.html">Releases</a>
             <a href="map.html" class="active">Map</a>
             <a href="timeline.html">Timeline</a>

--- a/src/js/lib/shared.js
+++ b/src/js/lib/shared.js
@@ -15,7 +15,7 @@ export function highlightActiveNav() {
         // Clear any existing 'active' class
         link.classList.remove('active');
         // Add 'active' class if the link href matches the current page URL
-        if (linkUrl === currentPageUrl || (currentPageUrl === '' && linkUrl === 'index.html')) {
+        if (linkUrl === currentPageUrl || ((currentPageUrl === '' || currentPageUrl === 'index.html') && linkUrl === '.')) {
             link.classList.add('active');
         }
     });

--- a/src/js/main.js
+++ b/src/js/main.js
@@ -21,7 +21,7 @@ function route() {
     const currentPage = window.location.pathname.split('/').pop();
 
     // Route to page-specific logic
-    if (currentPage === 'index.html' || currentPage === '') {
+    if (currentPage === '' || currentPage === 'index.html') {
         initHomePage();
     } else if (currentPage === 'games.html') {
         initReleasesPage();

--- a/timeline.html
+++ b/timeline.html
@@ -35,7 +35,7 @@
     <header>
         <h1>Zemurian Atlas</h1>
         <nav class="main-navigation">
-            <a href="index.html">Home</a>
+            <a href="./">Home</a>
             <a href="games.html">Releases</a>
             <a href="map.html">Map</a>
             <a href="timeline.html" class="active">Timeline</a>


### PR DESCRIPTION
Replaced all instances of `index.html` in navigation links with `./` to ensure a cleaner URL structure.

Updated the JavaScript routing and active navigation highlighting logic to correctly handle the new root-relative links for the home page.