### PR TITLE
Update favicon and web manifest references

### DIFF
--- a/games.html
+++ b/games.html
@@ -24,9 +24,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:ital,wght@1,700&display=swap" rel="stylesheet">
-    <link rel="icon" href="favicon.png" sizes="16x16 32x32" type="image/png">
-    <link rel="apple-touch-icon" href="favicon.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <link rel="icon" href="favicon-96x96.png" type="image/png">
+    <link rel="apple-touch-icon" href="apple-touch-icon.png">
+    <link rel="manifest" href="site.webmanifest">
     <script src="src/js/main.js" type="module" defer></script>
     <script data-goatcounter="https://jun-eau.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </head>

--- a/index.html
+++ b/index.html
@@ -24,9 +24,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:ital,wght@1,700&display=swap" rel="stylesheet">
-    <link rel="icon" href="favicon.png" sizes="16x16 32x32" type="image/png">
-    <link rel="apple-touch-icon" href="favicon.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <link rel="icon" href="favicon-96x96.png" type="image/png">
+    <link rel="apple-touch-icon" href="apple-touch-icon.png">
+    <link rel="manifest" href="site.webmanifest">
     <script src="src/js/main.js" type="module" defer></script>
     <script data-goatcounter="https://jun-eau.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </head>

--- a/map.html
+++ b/map.html
@@ -24,9 +24,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:ital,wght@1,700&display=swap" rel="stylesheet">
-    <link rel="icon" href="favicon.png" sizes="16x16 32x32" type="image/png">
-    <link rel="apple-touch-icon" href="favicon.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <link rel="icon" href="favicon-96x96.png" type="image/png">
+    <link rel="apple-touch-icon" href="apple-touch-icon.png">
+    <link rel="manifest" href="site.webmanifest">
     <script src="src/js/main.js" type="module" defer></script>
     <script data-goatcounter="https://jun-eau.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </head>

--- a/site.webmanifest
+++ b/site.webmanifest
@@ -3,13 +3,13 @@
   "short_name": "Zemurian Atlas",
   "icons": [
     {
-      "src": "/web-app-manifest-192x192.png",
+      "src": "web-app-manifest-192x192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/web-app-manifest-512x512.png",
+      "src": "web-app-manifest-512x512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"

--- a/timeline.html
+++ b/timeline.html
@@ -24,9 +24,10 @@
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&family=Playfair+Display:ital,wght@1,700&display=swap" rel="stylesheet">
-    <link rel="icon" href="favicon.png" sizes="16x16 32x32" type="image/png">
-    <link rel="apple-touch-icon" href="favicon.png">
-    <link rel="manifest" href="/site.webmanifest">
+    <link rel="icon" href="favicon.svg" type="image/svg+xml">
+    <link rel="icon" href="favicon-96x96.png" type="image/png">
+    <link rel="apple-touch-icon" href="apple-touch-icon.png">
+    <link rel="manifest" href="site.webmanifest">
     <script src="src/js/main.js" type="module" defer></script>
     <script data-goatcounter="https://jun-eau.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
 </head>


### PR DESCRIPTION
Updates all HTML files to use the new favicon.svg and a PNG fallback. Also updates the apple-touch-icon link.

The site.webmanifest file is updated to use relative paths for the icons, and the manifest link in the HTML files is updated to a relative path.