### PR TITLE
feat: Add JSON-LD structured data for SEO

### DIFF
--- a/games.html
+++ b/games.html
@@ -20,6 +20,16 @@
     <meta property="twitter:title" content="Zemurian Atlas - List of All Trails Game Releases">
     <meta property="twitter:description" content="A visual guide to the Trails (Kiseki) series, including release / in-game timelines and an interactive map.">
     <meta property="twitter:image" content="https://jun-eau.github.io/zemurian-atlas/assets/social-preview.jpg">
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "url": "https://jun-eau.github.io/zemurian-atlas/",
+      "name": "Zemurian Atlas"
+    }
+    </script>
+
     <link rel="stylesheet" href="src/css/style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,16 @@
     <meta property="twitter:title" content="Zemurian Atlas - A Visual Guide to the Trails Series">
     <meta property="twitter:description" content="A visual guide to the Trails (Kiseki) series, including release / in-game timelines and an interactive map.">
     <meta property="twitter:image" content="https://jun-eau.github.io/zemurian-atlas/assets/social-preview.jpg">
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "url": "https://jun-eau.github.io/zemurian-atlas/",
+      "name": "Zemurian Atlas"
+    }
+    </script>
+
     <link rel="stylesheet" href="src/css/style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/map.html
+++ b/map.html
@@ -20,6 +20,16 @@
     <meta property="twitter:title" content="Zemurian Atlas - Interactive Map of Zemuria">
     <meta property="twitter:description" content="A visual guide to the Trails (Kiseki) series, including release / in-game timelines and an interactive map.">
     <meta property="twitter:image" content="https://jun-eau.github.io/zemurian-atlas/assets/social-preview.jpg">
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "url": "https://jun-eau.github.io/zemurian-atlas/",
+      "name": "Zemurian Atlas"
+    }
+    </script>
+
     <link rel="stylesheet" href="src/css/style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/timeline.html
+++ b/timeline.html
@@ -20,6 +20,16 @@
     <meta property="twitter:title" content="Zemurian Atlas - Narrative Timeline of the Trails Series">
     <meta property="twitter:description" content="A visual guide to the Trails (Kiseki) series, including release / in-game timelines and an interactive map.">
     <meta property="twitter:image" content="https://jun-eau.github.io/zemurian-atlas/assets/social-preview.jpg">
+
+    <script type="application/ld+json">
+    {
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      "url": "https://jun-eau.github.io/zemurian-atlas/",
+      "name": "Zemurian Atlas"
+    }
+    </script>
+
     <link rel="stylesheet" href="src/css/style.css">
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
Adds a JSON-LD script block to the <head> of all HTML pages. This provides structured data to search engines, explicitly defining the website's name as "Zemurian Atlas".

This change is intended to resolve an issue where Google search results were displaying the site's title as "github.io" instead of the intended name.