### PR TITLE
Fix: Adjust map page text and mobile visibility

### DIFF
--- a/map.html
+++ b/map.html
@@ -60,7 +60,7 @@
             <div class="full-width-section">
                 <h2>Interactive Map</h2>
                 <p style="font-size: 0.9em; font-style: italic; text-align: center; margin-bottom: 15px;">
-                    Map image sourced from the <a href="https://falcom.wiki/wiki/Zemuria?file=Zemuria_%282023_ver%29.png" target="_blank" rel="noopener noreferrer">Falcom Wiki</a>.<br>Hover over a region to highlight it, and click to see information about that region.<br>Best viewed on desktop; functionality on small screens is not guaranteed.
+                    Map image sourced from the <a href="https://falcom.wiki/wiki/Zemuria?file=Zemuria_%282023_ver%29.png" target="_blank" rel="noopener noreferrer">Falcom Wiki</a>.<br>Hover over a region to highlight it, and click to see information about that region.
                 </p>
                 <div class="map-container">
                     <img src="assets/zemuria-map.webp" alt="Map of Zemuria" class="map-image">
@@ -83,8 +83,8 @@
                     </svg>
                 </div>
             </div>
-            <div id="mobile-map-container">
-                <div id="mobile-map-banner" class="map-banner">Tap a region to explore!</div>
+            <div id="mobile-map-container" class="mobile-only">
+                <div id="mobile-map-banner" class="map-banner">Tap on a region for more details!</div>
             </div>
 
             <!-- Static Infobox Structure -->


### PR DESCRIPTION
This commit addresses three issues on the interactive map page:

1. The informational text "Best viewed on desktop; functionality on small screens is not guaranteed" has been removed entirely.
2. The banner text on mobile has been changed from "Tap on a region to explore!" to the more descriptive "Tap on a region for more details!".
3. The mobile map container and its banner are now correctly hidden on desktop views by applying the existing `mobile-only` CSS class. This ensures the banner only appears on small screens as intended.