### PR TITLE
Fix: Adjust map page text and mobile visibility

### DIFF
--- a/map.html
+++ b/map.html
@@ -83,7 +83,7 @@
                     </svg>
                 </div>
             </div>
-            <div id="mobile-map-container" class="mobile-only">
+            <div id="mobile-map-container">
                 <div id="mobile-map-banner" class="map-banner">Tap on a region for more details!</div>
             </div>
 

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1128,6 +1128,7 @@ body.home-page::before {
         display: none;
     }
     #mobile-map-container {
+        display: block;
         /* Header is 114px high on mobile */
         height: calc(100vh - 114px);
         width: 100%;
@@ -1318,6 +1319,9 @@ body.home-page::before {
 
 /* --- Initial Hiding of Mobile/Desktop Specific Elements --- */
 /* This is out of the media query to ensure it's a base style. */
+#mobile-map-container {
+    display: none;
+}
 .mobile-only {
     display: none;
 }


### PR DESCRIPTION
This commit addresses three issues on the interactive map page:

1. The informational text "Best viewed on desktop; functionality on small screens is not guaranteed" has been removed entirely.
2. The banner text on mobile has been changed from "Tap on a region to explore!" to the more descriptive "Tap on a region for more details!".
3. The mobile map container and its banner are now correctly hidden on desktop views and shown on mobile by applying CSS rules directly to the element's ID. This avoids a race condition that was causing the map to fail to initialize on mobile.